### PR TITLE
Fix postgres don't have permissions to data folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     image: postgres:11-alpine
     restart: unless-stopped
     volumes: 
-      - "./data//postgres:/var/lib/postgresql/data"
+      - "./data//postgres:/var/lib/postgresql/data2:z"
   s3:
     #image: lphoward/fake-s3
     build: fakes3/


### PR DESCRIPTION
I was getting errors:
initdb: could not access directory "/var/lib/postgresql/data": Permission denied

Environment: mac OS 10.14.6

My pull request fixes the error.